### PR TITLE
defend against incidents with missing trigger_summary_data

### DIFF
--- a/pd2pg.rb
+++ b/pd2pg.rb
@@ -113,10 +113,13 @@ class PG2PD
       incident_key: i["incident_key"],
       service_id: i["service"] && i["service"]["id"],
       escalation_policy_id: i["escalation_policy"] && i["escalation_policy"]["id"],
-      trigger_summary_subject: i["trigger_summary_data"]["subject"],
-      trigger_summary_description: i["trigger_summary_data"]["description"],
       trigger_type: i["trigger_type"]
-    }
+    }.tap do |data|
+      if i["trigger_summary_data"]
+        data["trigger_summary_subject"] = i["trigger_summary_data"]["subject"]
+        data["trigger_summary_description"] = i["trigger_summary_data"]["description"]
+      end
+    end
   end
 
   # Refresh database state for the given table by fetching all relevant


### PR DESCRIPTION
I found some cases in which incidents did not have this data, causing the entire pipeline to break down.

Looking at the specific incidents, they were triggered via email instead of via the more traditional API.  I'm not sure how common that is, but I had a large number of them.
