### PR TITLE
updated schema to include more escalation policy and schedule data

### DIFF
--- a/pd2pg.rb
+++ b/pd2pg.rb
@@ -70,19 +70,19 @@ class PG2PD
     }
   end
 
-  def convert_schedule(s)
-    refresh_bulk(:users,
-                 :user_schedule,
-                 "schedules/#{s["id"]}/users",
-                 { since: Time.now.strftime("%Y-%m-%d") },
-                 false) {
-      |u| convert_user_schedule(u, s["id"])
-    }
-    {
-      id: s["id"],
-      name: s["name"]
-    }
-  end
+def convert_schedule(s)
+  refresh_bulk(:users,
+               :user_schedule,
+               "schedules/#{s['id']}/users",
+               { since: Time.now.strftime('%Y-%m-%d') },
+               false) do |u|
+                 convert_user_schedule(u, s['id'])
+               end
+  {
+    id: s['id'],
+    name: s['name']
+  }
+end
 
   def convert_user_schedule(u, schedule_id)
     {

--- a/schema.sql
+++ b/schema.sql
@@ -33,6 +33,31 @@ create table services (
 
 create table escalation_policies (
   id varchar primary key,
+  name varchar not null,
+  num_loops int not null
+);
+
+create table escalation_rules (
+  id varchar primary key,
+  escalation_policy_id varchar not null,
+  escalation_delay_in_minutes int,
+  level_index int
+);
+
+create table escalation_rule_users (
+  id varchar primary key,
+  escalation_rule_id varchar not null,
+  user_id varchar
+);
+
+create table escalation_rule_schedules (
+  id varchar primary key,
+  escalation_rule_id varchar not null,
+  schedule_id varchar
+);
+
+create table schedules (
+  id varchar primary key,
   name varchar not null
 );
 
@@ -40,6 +65,12 @@ create table users (
   id varchar primary key,
   name varchar not null,
   email varchar not null
+);
+
+create table user_schedule (
+  id varchar primary key,
+  user_id varchar,
+  schedule_id varchar
 );
 
 -- Extension tablefunc enables crosstabs.


### PR DESCRIPTION
#### Summary
Pull more data from the PagerDuty v1 API. The schema now includes escalation rules and which users are in each schedule. The new tables are: escalation_rules, escalation_rule_users, escalation_rule_schedules, and user_schedule. escalation_policies also now includes a column for how many times it loops.

#### Motivation
We want to use this data to do more analysis on our use of PD.

#### Test plan
Ran on local machine and wrote SQL queries for sanity testing.

#### Rollout/monitoring/revert plan
None

#### Reviewer expectation
Comments on the schema choices would be helpful, because I wasn't sure if I was representing the PD data with the right SQL idioms.