### PR TITLE
fix bug where user_schedule table wasn't being stored

### DIFF
--- a/bin/pd2pg
+++ b/bin/pd2pg
@@ -75,25 +75,28 @@ class PG2PD
   end
 
   # Adds users to user_schedule table associated with given schedule.
-  def user_schedules_to_db(items, schedule_id)
+  def user_schedules_to_db(schedule_items)
     columns = [:id, :user_id, :schedule_id]
-    records = items.map do |i|
-      ["#{i['id']}_#{schedule_id}",
-       i['id'],
-       schedule_id]
+    all_records = []
+    schedule_items.each do |s|
+      users = get_bulk(:users,
+                                "schedules/#{s['id']}/users",
+                                { since: Time.now.strftime('%Y-%m-%d') },
+                                false)
+      records = users.map do |u|
+        ["#{u['id']}_#{s['id']}",
+         u['id'],
+         s['id']]
+      end
+      all_records.concat(records)
     end
-    database_update(:user_schedule, columns, records)
+    database_update(:user_schedule, columns, all_records)
   end
 
   # Send all schedule records from Pagerduty to database.
   def schedules_to_db(items)
-    items.each do |i|
-      user_schedules = get_bulk(:users,
-                                "schedules/#{i['id']}/users",
-                                { since: Time.now.strftime('%Y-%m-%d') },
-                                false)
-      user_schedules_to_db(user_schedules, i['id'])
-    end
+    user_schedules_to_db(items)
+
     columns = [:id, :name]
     records = items.map do |i|
       [i['id'],

--- a/bin/pd2pg
+++ b/bin/pd2pg
@@ -71,7 +71,7 @@ class PG2PD
        i['status'],
        i['type']]
     end
-    database_update(:services, columns, records)
+    database_replace(:services, columns, records)
   end
 
   # Adds users to user_schedule table associated with given schedule.
@@ -80,17 +80,14 @@ class PG2PD
     all_records = []
     schedule_items.each do |s|
       users = get_bulk(:users,
-                                "schedules/#{s['id']}/users",
-                                { since: Time.now.strftime('%Y-%m-%d') },
-                                false)
-      records = users.map do |u|
-        ["#{u['id']}_#{s['id']}",
-         u['id'],
-         s['id']]
+                       "schedules/#{s['id']}/users",
+                       { since: Time.now.strftime('%Y-%m-%d') },
+                       false)
+      users.each do |u|
+        all_records << ["#{u['id']}_#{s['id']}", u['id'], s['id']]
       end
-      all_records.concat(records)
     end
-    database_update(:user_schedule, columns, all_records)
+    database_replace(:user_schedule, columns, all_records)
   end
 
   # Send all schedule records from Pagerduty to database.
@@ -102,7 +99,7 @@ class PG2PD
       [i['id'],
        i['name']]
     end
-    database_update(:schedules, columns, records)
+    database_replace(:schedules, columns, records)
   end
 
   # Send all escalation policy records from Pagerduty to database.
@@ -146,10 +143,10 @@ class PG2PD
         end
       end
     end
-    database_update(:escalation_rules, er_columns, er_records)
-    database_update(:escalation_rule_users, eru_columns, eru_records)
-    database_update(:escalation_rule_schedules, ers_columns, ers_records)
-    database_update(:escalation_policies, ep_columns, ep_records)
+    database_replace(:escalation_rules, er_columns, er_records)
+    database_replace(:escalation_rule_users, eru_columns, eru_records)
+    database_replace(:escalation_rule_schedules, ers_columns, ers_records)
+    database_replace(:escalation_policies, ep_columns, ep_records)
   end
 
   # Send all user records to database.
@@ -160,7 +157,7 @@ class PG2PD
        i['name'],
        i['email']]
     end
-    database_update(:users, columns, records)
+    database_replace(:users, columns, records)
   end
 
   # Convert log entry API value into a DB record.
@@ -225,8 +222,8 @@ class PG2PD
     return records
   end
 
-  def database_update(table_name, columns, records)
-    # Atomically update the DB, handling both data changes and insertions.
+  def database_replace(table_name, columns, records)
+    # Atomically update the given table. Deletes the contents of the table before inserting the new records.
     db.transaction do
       table = db[table_name]
       table.delete()


### PR DESCRIPTION
#### Summary
In [#11](https://github.com/stripe/pd2pg/pull/11), I changed `database_update` to clear out the old database records before entering new ones, in order to account for deleted schedules and users. 

For the user_schedule table, I was calling `database_update` for each schedule, which caused it to delete whatever was in there before. This PR fixes this bug by only calling `database_update` once for all of the user_schedule records.

#### Testing
Ran locally and checked that the records were actually being stored.