### PR TITLE
Update pd2pg to support Pagerduty API v2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ often as you'd like to refresh your database.
 
 You'll need the following config set in environment variables:
 
-* `PAGERDUTY_SUBDOMAIN`: e.g. `your-company` in `your-company.pagerduty.com`.
 * `PAGERDUTY_API_KEY`: a read-only API key from `https://<PAGERDUTY_SUBDOMAIN>.pagerduty.com/api_keys`.
 * `DATABASE_URL`: URL to a Postgres database, e.g. `postgres://127.0.0.1:5432/pagerduty`
 

--- a/bin/pd2pg
+++ b/bin/pd2pg
@@ -48,15 +48,17 @@ class PG2PD
   def initialize
     # Read config.
     database_url = env!("DATABASE_URL")
-    pagerduty_subdomain = env!("PAGERDUTY_SUBDOMAIN")
     pagerduty_api_token = env!("PAGERDUTY_API_KEY")
 
     # Establish API connection.
     self.api = Excon::Connection.new(
       :scheme => "https",
-      :host => "#{pagerduty_subdomain}.pagerduty.com",
+      :host => "api.pagerduty.com",
       :port => 443,
-      :headers => {"Authorization" => "Token token=#{pagerduty_api_token}"})
+      :headers => {
+        "Authorization" => "Token token=#{pagerduty_api_token}",
+        "Accept" => "application/vnd.pagerduty+json;version=2"
+      })
 
     # Establish DB connection.
     self.db = Sequel.connect(database_url)
@@ -181,7 +183,7 @@ class PG2PD
     {
       id: i["id"],
       incident_number: i["incident_number"],
-      created_at: i["created_on"],
+      created_at: i["created_at"],
       html_url: i["html_url"],
       incident_key: i["incident_key"],
       service_id: i["service"] && i["service"]["id"],
@@ -207,8 +209,12 @@ class PG2PD
       end
       response = api.request(
         method: :get,
-        path: "/api/v1/#{endpoint}",
-        query: {'offset' => offset, 'limit' => PAGINATION_LIMIT}.merge(additional_headers),
+        path: "/#{endpoint}",
+        query: {
+          'offset' => offset,
+          'limit' => PAGINATION_LIMIT,
+          'total' => 'true'
+        }.merge(additional_headers),
         expects: [200]
       )
       data = JSON.parse(response.body)
@@ -261,12 +267,13 @@ class PG2PD
         log("refresh_incremental.page", collection: collection, offset: offset, total: total || "?")
         response = api.request(
           method: :get,
-          path: "/api/v1/#{collection}",
+          path: "/#{collection}",
           query: {
-            since: since,
-            until: through,
+            since: since.iso8601,
+            until: through.iso8601,
             offset: offset,
-            limit: PAGINATION_LIMIT
+            limit: PAGINATION_LIMIT,
+            total: 'true'
           }.merge(query_params),
           expects: [200]
         )


### PR DESCRIPTION
This PR updates pd2pg to support Pagerduty API v2.

- Removal of /api/v1 URIs
- Removal of PAGEDUTY_SUBDOMAIN as v2 API uses api.pagerduty.com

This was tested importing about 3 million records (incidents and log_entries mostly) without any issues. 

I would appreciate more tests thou.

Thanks
