### PR TITLE
switch to pagerduty v2 api

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ often as you'd like to refresh your database.
 
 You'll need the following config set in environment variables:
 
-* `PAGERDUTY_SUBDOMAIN`: e.g. `your-company` in `your-company.pagerduty.com`.
-* `PAGERDUTY_API_KEY`: a read-only API key from `https://<PAGERDUTY_SUBDOMAIN>.pagerduty.com/api_keys`.
+* `PAGERDUTY_API_KEY`: a read-only API key from `https://api.pagerduty.com/api_keys`.
 * `DATABASE_URL`: URL to a Postgres database, e.g. `postgres://127.0.0.1:5432/pagerduty`
 
 Perform a one-time schema load with:

--- a/bin/pd2pg
+++ b/bin/pd2pg
@@ -203,21 +203,26 @@ class PG2PD
     offset = 0
     total = nil
     records = []
-    while !total || offset <= total
+    loop {
       if should_log
         log('get_bulk.page', collection: collection, offset: offset, total: total || '?')
       end
       response = api.request(
         method: :get,
         path: "/#{endpoint}",
-        query: {'total' => true, 'offset' => offset, 'limit' => PAGINATION_LIMIT}.merge(additional_headers),
+        query: {
+            'total' => true,
+            'offset' => offset,
+            'limit' => PAGINATION_LIMIT
+        }.merge(additional_headers),
         expects: [200]
       )
       data = JSON.parse(response.body)
       total = data["total"] || data[collection.to_s].length
       offset += PAGINATION_LIMIT
       records.concat(data[collection.to_s])
-    end
+      break if !data["more"]
+    }
     if should_log
       log('get_bulk.update', collection: collection, total: records.length)
     end
@@ -259,8 +264,7 @@ class PG2PD
       offset = 0
       total = nil
       records = []
-      more = true
-      while more
+      loop {
         log("refresh_incremental.page", collection: collection, since: since, offset: offset, total: total || "?")
         response = api.request(
           method: :get,
@@ -276,11 +280,11 @@ class PG2PD
         )
         data = JSON.parse(response.body)
         total = data["total"]
-        more = data["more"]
         offset += PAGINATION_LIMIT
         items = data[collection.to_s]
         records.concat(items.map { |i| yield(i) })
-      end
+        break if !data["more"]
+      }
 
       # Atomically update the DB by inserting all novel records.
       if !records.empty?

--- a/bin/pd2pg
+++ b/bin/pd2pg
@@ -2,8 +2,6 @@
 
 require "json"
 require "excon"
-require "time"
-require "pg"
 require "sequel"
 
 # Ensure all data processing and storage is in UTC.
@@ -48,15 +46,17 @@ class PG2PD
   def initialize
     # Read config.
     database_url = env!("DATABASE_URL")
-    pagerduty_subdomain = env!("PAGERDUTY_SUBDOMAIN")
     pagerduty_api_token = env!("PAGERDUTY_API_KEY")
 
     # Establish API connection.
     self.api = Excon::Connection.new(
       :scheme => "https",
-      :host => "#{pagerduty_subdomain}.pagerduty.com",
+      :host => "api.pagerduty.com",
       :port => 443,
-      :headers => {"Authorization" => "Token token=#{pagerduty_api_token}"})
+      :headers => {
+          "Authorization" => "Token token=#{pagerduty_api_token}",
+          "Accept" => "application/vnd.pagerduty+json;version=2"
+      })
 
     # Establish DB connection.
     self.db = Sequel.connect(database_url)
@@ -181,14 +181,16 @@ class PG2PD
     {
       id: i["id"],
       incident_number: i["incident_number"],
-      created_at: i["created_on"],
+      created_at: i["created_at"],
       html_url: i["html_url"],
       incident_key: i["incident_key"],
       service_id: i["service"] && i["service"]["id"],
       escalation_policy_id: i["escalation_policy"] && i["escalation_policy"]["id"],
-      trigger_type: i["trigger_type"],
-      trigger_summary_subject: i["trigger_summary_data"] && i["trigger_summary_data"]["subject"],
-      trigger_summary_description: i["trigger_summary_data"] && i["trigger_summary_data"]["description"]
+      trigger_summary_subject: i["summary"],
+      trigger_summary_description: i["description"],
+      # this column is no longer supported in Pagerduty's v2 API
+      # we're leaving it in for backwards compatibility.
+      trigger_type: "DEPRECATED"
     }
   end
 
@@ -207,8 +209,8 @@ class PG2PD
       end
       response = api.request(
         method: :get,
-        path: "/api/v1/#{endpoint}",
-        query: {'offset' => offset, 'limit' => PAGINATION_LIMIT}.merge(additional_headers),
+        path: "/#{endpoint}",
+        query: {'total' => true, 'offset' => offset, 'limit' => PAGINATION_LIMIT}.merge(additional_headers),
         expects: [200]
       )
       data = JSON.parse(response.body)
@@ -257,12 +259,14 @@ class PG2PD
       offset = 0
       total = nil
       records = []
-      while !total || offset <= total
-        log("refresh_incremental.page", collection: collection, offset: offset, total: total || "?")
+      more = true
+      while more
+        log("refresh_incremental.page", collection: collection, since: since, offset: offset, total: total || "?")
         response = api.request(
           method: :get,
-          path: "/api/v1/#{collection}",
+          path: "/#{collection}",
           query: {
+            total: true,
             since: since,
             until: through,
             offset: offset,
@@ -272,6 +276,7 @@ class PG2PD
         )
         data = JSON.parse(response.body)
         total = data["total"]
+        more = data["more"]
         offset += PAGINATION_LIMIT
         items = data[collection.to_s]
         records.concat(items.map { |i| yield(i) })

--- a/schema.sql
+++ b/schema.sql
@@ -8,7 +8,7 @@ create table incidents (
   escalation_policy_id varchar,
   trigger_summary_subject varchar,
   trigger_summary_description varchar,
-  trigger_type varchar not null
+  trigger_type varchar
 );
 
 create table log_entries (


### PR DESCRIPTION
Pagerduty's v1 REST API will be [deprecated in October](https://v2.developer.pagerduty.com/docs/migrating-to-api-v2).

This change switches to the v2 API without changing any columns.