### PR TITLE
Upgrading excon to version 0.71.0 as per guidance around recently-dis…

### DIFF
--- a/pd2pg.gemspec
+++ b/pd2pg.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
 
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'excon', '~> 0.54'
+  gem.add_dependency "excon", ">= 0.71.0"
   gem.add_dependency 'pg', '~> 0.18'
   gem.add_dependency 'sequel', '~> 4'
 end


### PR DESCRIPTION
…covered vuln

Just bumping the excon version number to a non-vulnerable version like the guidance recommended. 

Not sure how to test this. I'm also not sure if ~> is more appropriate than the >= that the automation suggested. I'm happy to switch if you think that would be better.