### PR TITLE
Add escalation ids to services

### DIFF
--- a/bin/pd2pg
+++ b/bin/pd2pg
@@ -20,7 +20,7 @@ class PG2PD
   INCREMENTAL_WINDOW = 60*60*24
 
   # Earliest time PagerDuty data could be available.
-  PAGERDUTY_EPOCH = Time.parse("2018-01-01T00:00Z")
+  PAGERDUTY_EPOCH = Time.parse("2009-01-01T00:00Z")
 
   # Reads required config from environment variables.
   def env!(k)

--- a/bin/pd2pg
+++ b/bin/pd2pg
@@ -20,7 +20,7 @@ class PG2PD
   INCREMENTAL_WINDOW = 60*60*24
 
   # Earliest time PagerDuty data could be available.
-  PAGERDUTY_EPOCH = Time.parse("2009-01-01T00:00Z")
+  PAGERDUTY_EPOCH = Time.parse("2018-01-01T00:00Z")
 
   # Reads required config from environment variables.
   def env!(k)
@@ -64,12 +64,13 @@ class PG2PD
 
   # Send all service records from Pagerduty to database.
   def services_to_db(items)
-    columns = [:id, :name, :status, :type]
+    columns = [:id, :name, :status, :type, :escalation_id]
     records = items.map do |i|
       [i['id'],
        i['name'],
        i['status'],
-       i['type']]
+       i['type'],
+       i['escalation_policy']['id']]
     end
     database_replace(:services, columns, records)
   end

--- a/schema.sql
+++ b/schema.sql
@@ -29,7 +29,7 @@ create table services (
   name varchar not null,
   status varchar not null,
   type varchar not null,
-  escalation_id varchar,
+  escalation_id varchar
 );
 
 create table escalation_policies (

--- a/schema.sql
+++ b/schema.sql
@@ -28,7 +28,8 @@ create table services (
   id varchar primary key,
   name varchar not null,
   status varchar not null,
-  type varchar not null
+  type varchar not null,
+  escalation_id varchar,
 );
 
 create table escalation_policies (


### PR DESCRIPTION
PR to add escalation policy id `escalation_id` to the services table.

The point of this PR is to enable joining of the `services` and `escalation_policies` table on `escalation_id`. This is helpful in being able to easily determine the escalation policy of a service.  Right now it is only possible to get a services escalation policy by going through a particular incident (joining `services` and `incidents` and `incidents` and `escalation_policies`). This is not entirely reliable as services policies can be changed. Adding `escalation_id` is only a few lines change as the ID is easily available in the JSON response from the pagerduty api.

**Locally verified**, able to create tables & load data with `escalation_id` now present in services table. 